### PR TITLE
Parsing CIRC FAILED, additional logging, excess workers sleep

### DIFF
--- a/src/torflow/README.md
+++ b/src/torflow/README.md
@@ -7,7 +7,7 @@ usage
 -----
 
 Torflow arguments should be configured as follows:
-	arguments="filename pausetime workers sliceSize nodeCap socksPort:ctlPort:socksPort:ctlPort:... server:port,server:port,..."
+	arguments="filename pausetime workers sliceSize nodeCap socksPort ctlPort server:port"
 
 The arguments are listed below, along with the value used by real TorFlow if
 applicable, and an explanation.
@@ -30,11 +30,9 @@ value.
 
  + socksPort: The port used to connect to the Tor instance.
 
- + ctlPort: The TorControl port, set in the arguments to the tor plugin. Use
-multiple socksPort:ctlPort pairs, joined by colons, one for each worker.
+ + ctlPort: The TorControl port, set in the arguments to the tor plugin.
 
  + server: The name of the test fileserver which TorFlow builds circuits to connect to.
 
- + port: The port to connect to on the test fileserver. Use multiple
-server:port pairs, joined by commas, one for each worker.
+ + port: The port to connect to on the test fileserver.
 

--- a/src/torflow/torflow-aggregator.c
+++ b/src/torflow/torflow-aggregator.c
@@ -264,7 +264,7 @@ void _torflowaggregator_readInitialAdvertisements(TorFlowAggregator* tfa) {
 	for(gint i = 0; i < tfa->numSlices; i++) {
 		tfa->seenSlice[i] = FALSE;
 	}
-	tfa->slogf(SHADOW_LOG_LEVEL_DEBUG, __FUNCTION__, "Expecting %d slices", tfa->numSlices);
+	tfa->slogf(SHADOW_LOG_LEVEL_DEBUG, __FUNCTION__, "Expecting at least %d slices", tfa->numSlices);
 
 	tfa->loadedInitial = TRUE;
 }

--- a/src/torflow/torflow-base.c
+++ b/src/torflow/torflow-base.c
@@ -781,8 +781,6 @@ void torflowbase_recordMeasurement(TorFlowBase* tfb, gint contentLength, gsize r
 	tfb->internal->exitRelay->t_total = g_slist_prepend(tfb->internal->exitRelay->t_total, GINT_TO_POINTER(totalTime));
 	tfb->internal->exitRelay->bytesPushed = g_slist_prepend(tfb->internal->exitRelay->bytesPushed, GINT_TO_POINTER(contentLength));
 	tfb->internal->exitRelay->measureCount++;
-
-	for 
 }
 
 void torflowbase_updateRelays(TorFlowBase* tfb, GSList* relays) {

--- a/src/torflow/torflow-base.c
+++ b/src/torflow/torflow-base.c
@@ -95,7 +95,7 @@ static void _torflowbase_processLineSync(TorFlowBase* tfb, GString* linebuf) {
 	} else if (tfb->internal->gettingDescriptors && g_strstr_len(linebuf->str, linebuf->len, " OK")) {
 		tfb->internal->gettingDescriptors = FALSE;
 		tfb->slogf(SHADOW_LOG_LEVEL_MESSAGE, tfb->id,
-				"got %i descriptors and %i measureable relays",
+				"got %i descriptors and %i measurable relays",
 				tfb->internal->numDescriptors,
 				tfb->internal->numRelays);
 		if(tfb->internal->eventHandlers.onDescriptorsReceived) {
@@ -679,7 +679,7 @@ gchar* torflowbase_selectNewPath(TorFlowBase* tfb, gint sliceSize, gint currSlic
 		currentNode = g_slist_next(currentNode);
 		i++; 
 	}
-
+	int all = unmeasured+measured+partial;
 	if (!numExits) {
 		tfb->slogf(SHADOW_LOG_LEVEL_WARNING, tfb->id, "No exits in slice %i - skipping slice", currSlice);
 		return NULL;
@@ -688,10 +688,10 @@ gchar* torflowbase_selectNewPath(TorFlowBase* tfb, gint sliceSize, gint currSlic
 		return NULL;	
 	} else if (MEASUREMENTS_PER_SLICE == 1) {
 		tfb->slogf(SHADOW_LOG_LEVEL_MESSAGE, tfb->id, "Slice %i progress (measured/total): %i/%i",
-				currSlice, measured, unmeasured+measured);
+				currSlice, measured, all);
 	} else {
-		tfb->slogf(SHADOW_LOG_LEVEL_MESSAGE, tfb->id, "Slice %i progress (measured/total): %i/%i (%i partially measured)%",
-				currSlice, measured, unmeasured+partial+measured, partial);
+		tfb->slogf(SHADOW_LOG_LEVEL_MESSAGE, tfb->id, "Slice %i progress (measured/total): %i/%i (%i partially measured)",
+				currSlice, measured, all, partial);
 	}
 
 	//choose uniformly from all entries and exits with the lowest measure count.

--- a/src/torflow/torflow-prober.c
+++ b/src/torflow/torflow-prober.c
@@ -76,7 +76,9 @@ static void _torflowprober_startNextProbeCallback(TorFlowProber* tfp) {
 	g_assert(tfp);
 	tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_DEBUG, tfp->_tf._base.id,
 			"Probe Complete, Building Next Circuit");
-	torflowbase_closeCircuit((TorFlowBase*)tfp, tfp->internal->measurementCircID);
+	if (tfp->internal->measurementCircID) {
+		torflowbase_closeCircuit((TorFlowBase*)tfp, tfp->internal->measurementCircID);
+	}
 	tfp->internal->measurementCircID = 0;
 	tfp->internal->measurementStreamID = 0;
 
@@ -236,7 +238,7 @@ static void _torflowprober_onFileDownloadComplete(TorFlowProber* tfp, gint conte
 	g_assert(tfp);
 
 	tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_MESSAGE, tfp->_tf._base.id,
-			"probe-complete path=%s bytes=%i time-to: rtt=%zu payload=%zu total=%zu",
+			"Probe complete. path=%s bytes=%i time-to: rtt=%zu payload=%zu total=%zu",
 			torflowbase_getCurrentPath((TorFlowBase*) tfp),
 			contentLength, roundTripTime, payloadTime, totalTime);
 

--- a/src/torflow/torflow-prober.c
+++ b/src/torflow/torflow-prober.c
@@ -150,7 +150,7 @@ static void _torflowprober_onDescriptorsReceived(TorFlowProber* tfp, GSList* rel
 	gdouble maxPct = ((gdouble)tfp->internal->workerID+1.0)/tfp->internal->numWorkers;
 	tfp->internal->minSlice = (gint)(numSlices * minPct);
 	tfp->internal->maxSlice = (gint)(numSlices * maxPct);
-	tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_DEBUG, tfp->_tf._base.id,
+	tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_MESSAGE, tfp->_tf._base.id,
 			"Measuring slices %d through %d", tfp->internal->minSlice, tfp->internal->maxSlice-1);
 	tfp->internal->currSlice =  tfp->internal->minSlice - 1;
 
@@ -163,8 +163,11 @@ static void _torflowprober_onDescriptorsReceived(TorFlowProber* tfp, GSList* rel
 
 	// Report an odd corner case where all slices are bad
 	if (tfp->internal->currSlice >= tfp->internal->maxSlice) {
-		tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_CRITICAL, tfp->_tf._base.id,
-			"No measureable slices for TorFlow!");
+		tfp->_tf._base.slogf(SHADOW_LOG_LEVEL_MESSAGE, tfp->_tf._base.id,
+			"No measurable slices for this worker!");
+		tfp->_tf._base.scbf((BootstrapCompleteFunc)_torflowprober_onBootstrapComplete,
+			tfp, 1000*WORKER_RETRY_TIME);
+		
 	}
 }
 

--- a/src/torflow/torflow.h
+++ b/src/torflow/torflow.h
@@ -6,6 +6,7 @@
 #define TORFLOW_H_
 
 #define MEASUREMENTS_PER_SLICE 5
+#define WORKER_RETRY_TIME 300
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
* Torflow now parses CIRC FAILED lines and responds to them by starting a new circuit. It had been missing this step, which was causing some workers to stall and never make any more progress if a circuit failed to build.
* When a circuit timeouts, it's counted as a successful measurement even though no data was recorded (as real Torflow does), but now it will not do this if we are only ever doing one measurement per relay.
* Added a log line to report on progress within a slice.
* Corrected the log line about fetching descriptors to note the difference between measurable (fast, running) relays, and all descriptors received, and moved it from the info level to the message level.
* If a worker has no usable slices, it emits a "No measurable slices for this worker!" message, and then sleeps for 5 minutes (configurable in torflow.h) before fetching descriptors again. As a side note, if this message occurs without a "No exits in slice" or "No entries in slice" message before it, it means there are more workers than slices. This is possible because relays that do not have the fast flag do not count for TorFlow. Unless all workers have this message, the rest of the workers are doing their job and producing data.
* Clarified a couple of other log lines such as the one when a slice finishes or a probe finishes.
* The Torflow README.md is corrected.
