### PR TITLE
replace wget with cURL in setup

### DIFF
--- a/setup
+++ b/setup
@@ -554,11 +554,11 @@ def download(url, target_path):
             return 0
         except urllib2.URLError as e:
             logging.error("failed to download \'{0}\' using urllib2".format(url))
-            wgetpath = which("wget")
-            if wgetpath is not None:
-                retcode = subprocess.call(shlex.split("{0} {1}".format(wgetpath, url)))
+            curlpath = which("curl") + " -L -O"
+            if curlpath is not None:
+                retcode = subprocess.call(shlex.split("{0} {1}".format(curlpath, url)))
                 if retcode == 0:
-                    logging.info("successfully downloaded \'{0}\' using wget".format(url))
+                    logging.info("successfully downloaded \'{0}\' using curl".format(url))
                     return 0
             raise e
             return -1


### PR DESCRIPTION
wget fails to download certain dependencies due to issues with SSL; curl has no such issues (this follows up on the email I sent to you earlier today)