### PR TITLE
Fix undefined add_shadow_plugin

### DIFF
--- a/src/tor/CMakeLists.txt
+++ b/src/tor/CMakeLists.txt
@@ -160,6 +160,12 @@ remove_definitions(-DNDEBUG)
 add_cflags("-w -fPIC -fno-inline -fno-strict-aliasing -U_FORTIFY_SOURCE")
 
 ## create and install a shared library that can plug into shadow
+
+macro(add_shadow_plugin target)
+    add_bitcode(${target}-bitcode ${ARGN})
+    add_plugin(${target} ${target}-bitcode)
+endmacro(add_shadow_plugin)
+
 add_shadow_plugin(shadow-plugin-tor 
     shadowtor-main.c ${toror_sources} ${torcommon_sources} 
     ${torext_sources} ${torextcurve_sources} ${torextedref_sources} ${torexteddon_sources}


### PR DESCRIPTION
I fixed #23 by doing this. I do not know if this is the right way to do things as I have about 15 minutes of CMake experience now. I just copied the macro from https://github.com/shadow/shadow/blob/master/cmake/LLVMTools.cmake#L168

If this was actually necessary, I can't believe it went unnoticed for so long!

