### PR TITLE
tor-0.4.1.1-alpha split a crypto nss file up, so new file to ignore

### DIFF
--- a/src/tor/CMakeLists.txt.post035
+++ b/src/tor/CMakeLists.txt.post035
@@ -114,6 +114,7 @@ list(REMOVE_ITEM all_src
     ${TOR_ROOT_DIR}/src/lib/crypt_ops/crypto_dh_nss.c
     ${TOR_ROOT_DIR}/src/lib/crypt_ops/crypto_nss_mgt.c
     ${TOR_ROOT_DIR}/src/lib/crypt_ops/crypto_rsa_nss.c
+    ${TOR_ROOT_DIR}/src/lib/crypt_ops/crypto_digest_nss.c
     ${TOR_ROOT_DIR}/src/lib/lock/compat_mutex_winthreads.c
 )
 


### PR DESCRIPTION
Tor versions containing the following commit won't compile with shadow-plugin-tor. 

```
$ git show 5d538621
commit 5d53862139ea3244735834d7a89077f53cd3df76
Author: rl1987 <rl1987@sdf.lonestar.org>
Date:   Fri Jan 18 12:26:13 2019 +0200

    Split crypto_digest.c

    * Move out code that depends on NSS to crypto_digest_nss.c
    * Move out code that depends on OpenSSL to crypto_digest_openssl.c
    * Keep the general code that is not specific to any of the above in
      crypto_digest.c

diff --git a/changes/ticket29108 b/changes/ticket29108
new file mode 100644
index 0000000..7adb08e
--- /dev/null
+++ b/changes/ticket29108
@@ -0,0 +1,5 @@
+  o Code simplification and refactoring:
+    - Split crypto_digest.c into three parts: 1) general code that does not
+      depend on either NSS or OpenSSL (stays in crypto_digest.c); 2) code that
+      depends on NSS API (moved to crypto_digest_nss.c); 3) code that depends
+      on OpenSSL API (moved to crypto_digest_openssl.c). Resolves ticket 29108.
[... diff continues into actual code files ...]
```