### PR TITLE
Move continuous integration core logic into a shell script

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,34 +32,6 @@ jobs:
           ref: v1.13.2
           path: shadow
 
-      - name: Install compiler
-        run: |
-          case "${CC}" in
-            gcc)   sudo apt-get install -y gcc g++ ;;
-            clang) sudo apt-get install -y clang ;;
-            *) echo "bad cc=${CC}" && exit 1 ;;
-          esac
-
-      - name: Install shadow build deps
-        run: >
-          sudo apt-get install -y
-          cmake
-          make
-          xz-utils
-          python
-          libglib2.0-0
-          libglib2.0-dev
-          libigraph0v5
-          libigraph0-dev
-          libc-dbg
-          python-pyelftools
-
-      - name: Install Shadow
-        working-directory: ./shadow
-        run: |
-          ./setup build
-          ./setup install
-
       - name: Checkout tgen 
         uses: actions/checkout@v2
         with:
@@ -67,51 +39,18 @@ jobs:
           ref: v0.0.1
           path: tgen
 
-      - name: Install tgen build deps
-        run: >
-          sudo apt-get install -y
-          cmake
-          libglib2.0
-          libglib2.0-dev
-          libigraph0-dev
-          libigraph0v5
-
-      - name: Install tgen
-        working-directory: ./tgen
-        run: |
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.shadow
-          make install
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: shadow-plugin-tor
 
-      - name: Install shadow-plugin-tor build deps
-        run: >
-          sudo apt-get install -y
-          autoconf
-          automake
-          liblzma5
-          liblzma-dev
-          zlib1g-dev
+      - name: CI script
+        run: shadow-plugin-tor/tools/continuous_integration_test.sh
 
-      - name: Build
-        working-directory: ./shadow-plugin-tor
-        run: |
-          ./setup dependencies -y
-          ./setup build -y
-          ./setup install
-
-      - name: Simulate
-        working-directory: ./shadow-plugin-tor/resource
-        run: |
-          tar xaf shadowtor-minimal-config.tar.xz
-          mv shadowtor-minimal-config shadowtor-minimal
-          cd shadowtor-minimal
-          $HOME/.shadow/bin/shadow shadow.config.xml > shadow.log
-          COMPLETE=`find shadow.data/hosts -name '*client*.log' -exec grep transfer-complete \{\} \; | wc -l`
-          if [ $COMPLETE -ne 40 ]; then echo Expected 40 transfers got $COMPLETE; exit 1; fi
+      - name: Upload simulation logs
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: simulation-output
+          path: simulation
 

--- a/tools/continuous_integration_test.sh
+++ b/tools/continuous_integration_test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Continuous integration script. Builds and installs
+# shadow-plugin-tor and necessary dependencies, runs a simulation,
+# and validates the results.
+
+# Preconditions:
+#  * CC environment var set to preferred C compiler (gcc or clang)
+#  * ubuntu18 packages are available.
+#  * Run as a sudoer.
+#  * ./shadow-tor-plugin is source directory for shadow-tor-plugin.
+#  * ./shadow is source directory for shadow.
+#  * ./tgen is source directory for tgen.
+
+set -euo pipefail
+
+install_compiler () {
+    echo $FUNCNAME $@
+    case "$1" in
+      gcc)   sudo apt-get install -y gcc g++ ;;
+      clang) sudo apt-get install -y clang ;;
+      *) echo "bad cc=$1" && exit 1 ;;
+    esac
+}
+
+install_shadow_build_deps () {
+    echo $FUNCNAME $@
+    sudo apt-get install -y \
+        cmake \
+        make \
+        xz-utils \
+        python \
+        libglib2.0-0 \
+        libglib2.0-dev \
+        libigraph0v5 \
+        libigraph0-dev \
+        libc-dbg \
+        python-pyelftools
+}
+
+install_shadow () {
+    echo $FUNCNAME $@
+    pushd $1
+    ./setup build
+    ./setup install
+    popd
+}
+
+install_tgen_build_deps () {
+    echo $FUNCNAME $@
+    sudo apt-get install -y \
+        cmake \
+        libglib2.0 \
+        libglib2.0-dev \
+        libigraph0-dev \
+        libigraph0v5
+}
+
+install_tgen () {
+    echo $FUNCNAME $@
+    pushd $1
+    mkdir -p build
+    cd build
+    cmake .. -DCMAKE_INSTALL_PREFIX=$2
+    make install
+    popd
+}
+
+install_shadow_plugin_tor_build_deps () {
+    echo $FUNCNAME $@
+    sudo apt-get install -y \
+        autoconf \
+        automake \
+        liblzma5 \
+        liblzma-dev \
+        zlib1g-dev
+}
+
+install_shadow_plugin_tor () {
+    echo $FUNCNAME $@
+    pushd $1
+    ./setup dependencies -y
+    ./setup build -y
+    ./setup install
+    popd
+}
+
+run_simulation () {
+    echo $FUNCNAME $@
+    local SIMULATION_DIR=$1
+    local SHADOW_PLUGIN_TOR_SRC=$2
+    local SHADOW_BIN=$3
+
+    mkdir -p $SIMULATION_DIR
+    pushd $SIMULATION_DIR
+
+    tar xaf $SHADOW_PLUGIN_TOR_SRC/resource/shadowtor-minimal-config.tar.xz
+    mv shadowtor-minimal-config shadowtor-minimal
+    cd shadowtor-minimal
+    $SHADOW_BIN shadow.config.xml > shadow.log
+
+    popd
+}
+
+validate_simulation () {
+    echo $FUNCNAME $@
+    SIMULATION_DIR=$1
+
+    local COMPLETE=`find $SIMULATION_DIR/shadowtor-minimal/shadow.data/hosts -name '*client*.log' -exec grep transfer-complete \{\} \; | wc -l`
+    if [ $COMPLETE -ne 40 ]
+    then
+      echo Expected 40 transfers got $COMPLETE
+      return 1
+    fi
+}
+
+main () {
+    local INSTALL_PREFIX=$HOME/.shadow
+    local TGEN_SRC=$PWD/tgen
+    local SHADOW_SRC=$PWD/shadow
+    local SHADOW_PLUGIN_TOR_SRC=$PWD/shadow-plugin-tor
+    local SIMULATION_DIR=$PWD/simulation
+
+    install_compiler $CC
+
+    install_shadow_build_deps
+    install_shadow $SHADOW_SRC $INSTALL_PREFIX
+
+    install_tgen_build_deps
+    install_tgen $TGEN_SRC $INSTALL_PREFIX
+
+    install_shadow_plugin_tor_build_deps
+    install_shadow_plugin_tor $SHADOW_PLUGIN_TOR_SRC $INSTALL_PREFIX
+    
+    run_simulation $SIMULATION_DIR $SHADOW_PLUGIN_TOR_SRC $INSTALL_PREFIX/bin/shadow
+    validate_simulation $SIMULATION_DIR
+}
+
+main
+

--- a/tools/continuous_integration_test.sh
+++ b/tools/continuous_integration_test.sh
@@ -14,8 +14,13 @@
 
 set -euo pipefail
 
+TRACE_CMD='echo \
+&& echo "********************************" \
+&& echo $FUNCNAME $@ \
+&& echo "********************************"'
+
 install_compiler () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     case "$1" in
       gcc)   sudo apt-get install -y gcc g++ ;;
       clang) sudo apt-get install -y clang ;;
@@ -24,7 +29,7 @@ install_compiler () (
 )
 
 install_shadow_build_deps () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     sudo apt-get install -y \
         cmake \
         make \
@@ -39,14 +44,14 @@ install_shadow_build_deps () (
 )
 
 install_shadow () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     cd $1
     ./setup build
     ./setup install
 )
 
 install_tgen_build_deps () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     sudo apt-get install -y \
         cmake \
         libglib2.0 \
@@ -56,7 +61,7 @@ install_tgen_build_deps () (
 )
 
 install_tgen () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     cd $1
     mkdir -p build
     cd build
@@ -65,7 +70,7 @@ install_tgen () (
 )
 
 install_shadow_plugin_tor_build_deps () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     sudo apt-get install -y \
         autoconf \
         automake \
@@ -75,7 +80,7 @@ install_shadow_plugin_tor_build_deps () (
 )
 
 install_shadow_plugin_tor () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     cd $1
     ./setup dependencies -y
     ./setup build -y
@@ -83,7 +88,7 @@ install_shadow_plugin_tor () (
 )
 
 run_simulation () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     SIMULATION_DIR=$1
     SHADOW_PLUGIN_TOR_SRC=$2
     SHADOW_BIN=$3
@@ -98,7 +103,7 @@ run_simulation () (
 )
 
 validate_simulation () (
-    echo $FUNCNAME $@
+    eval "$TRACE_CMD"
     SIMULATION_DIR=$1
 
     COMPLETE=`find $SIMULATION_DIR/shadowtor-minimal/shadow.data/hosts -name '*client*.log' -exec grep transfer-complete \{\} \; | wc -l`

--- a/tools/continuous_integration_test.sh
+++ b/tools/continuous_integration_test.sh
@@ -14,16 +14,16 @@
 
 set -euo pipefail
 
-install_compiler () {
+install_compiler () (
     echo $FUNCNAME $@
     case "$1" in
       gcc)   sudo apt-get install -y gcc g++ ;;
       clang) sudo apt-get install -y clang ;;
       *) echo "bad cc=$1" && exit 1 ;;
     esac
-}
+)
 
-install_shadow_build_deps () {
+install_shadow_build_deps () (
     echo $FUNCNAME $@
     sudo apt-get install -y \
         cmake \
@@ -36,17 +36,16 @@ install_shadow_build_deps () {
         libigraph0-dev \
         libc-dbg \
         python-pyelftools
-}
+)
 
-install_shadow () {
+install_shadow () (
     echo $FUNCNAME $@
-    pushd $1
+    cd $1
     ./setup build
     ./setup install
-    popd
-}
+)
 
-install_tgen_build_deps () {
+install_tgen_build_deps () (
     echo $FUNCNAME $@
     sudo apt-get install -y \
         cmake \
@@ -54,19 +53,18 @@ install_tgen_build_deps () {
         libglib2.0-dev \
         libigraph0-dev \
         libigraph0v5
-}
+)
 
-install_tgen () {
+install_tgen () (
     echo $FUNCNAME $@
-    pushd $1
+    cd $1
     mkdir -p build
     cd build
     cmake .. -DCMAKE_INSTALL_PREFIX=$2
     make install
-    popd
-}
+)
 
-install_shadow_plugin_tor_build_deps () {
+install_shadow_plugin_tor_build_deps () (
     echo $FUNCNAME $@
     sudo apt-get install -y \
         autoconf \
@@ -74,52 +72,49 @@ install_shadow_plugin_tor_build_deps () {
         liblzma5 \
         liblzma-dev \
         zlib1g-dev
-}
+)
 
-install_shadow_plugin_tor () {
+install_shadow_plugin_tor () (
     echo $FUNCNAME $@
-    pushd $1
+    cd $1
     ./setup dependencies -y
     ./setup build -y
     ./setup install
-    popd
-}
+)
 
-run_simulation () {
+run_simulation () (
     echo $FUNCNAME $@
-    local SIMULATION_DIR=$1
-    local SHADOW_PLUGIN_TOR_SRC=$2
-    local SHADOW_BIN=$3
+    SIMULATION_DIR=$1
+    SHADOW_PLUGIN_TOR_SRC=$2
+    SHADOW_BIN=$3
 
     mkdir -p $SIMULATION_DIR
-    pushd $SIMULATION_DIR
+    cd $SIMULATION_DIR
 
     tar xaf $SHADOW_PLUGIN_TOR_SRC/resource/shadowtor-minimal-config.tar.xz
     mv shadowtor-minimal-config shadowtor-minimal
     cd shadowtor-minimal
     $SHADOW_BIN shadow.config.xml > shadow.log
+)
 
-    popd
-}
-
-validate_simulation () {
+validate_simulation () (
     echo $FUNCNAME $@
     SIMULATION_DIR=$1
 
-    local COMPLETE=`find $SIMULATION_DIR/shadowtor-minimal/shadow.data/hosts -name '*client*.log' -exec grep transfer-complete \{\} \; | wc -l`
+    COMPLETE=`find $SIMULATION_DIR/shadowtor-minimal/shadow.data/hosts -name '*client*.log' -exec grep transfer-complete \{\} \; | wc -l`
     if [ $COMPLETE -ne 40 ]
     then
       echo Expected 40 transfers got $COMPLETE
       return 1
     fi
-}
+)
 
-main () {
-    local INSTALL_PREFIX=$HOME/.shadow
-    local TGEN_SRC=$PWD/tgen
-    local SHADOW_SRC=$PWD/shadow
-    local SHADOW_PLUGIN_TOR_SRC=$PWD/shadow-plugin-tor
-    local SIMULATION_DIR=$PWD/simulation
+main () (
+    INSTALL_PREFIX=$HOME/.shadow
+    TGEN_SRC=$PWD/tgen
+    SHADOW_SRC=$PWD/shadow
+    SHADOW_PLUGIN_TOR_SRC=$PWD/shadow-plugin-tor
+    SIMULATION_DIR=$PWD/simulation
 
     install_compiler $CC
 
@@ -134,7 +129,7 @@ main () {
     
     run_simulation $SIMULATION_DIR $SHADOW_PLUGIN_TOR_SRC $INSTALL_PREFIX/bin/shadow
     validate_simulation $SIMULATION_DIR
-}
+)
 
 main
 


### PR DESCRIPTION
This will decouple us a bit more from Github's workflow/action framework, as well as allowing us to run this test from the shadow repo with less duplication.