### PR TITLE
New files to ignore as of (before) 0.4.4.0-alpha-dev

### DIFF
--- a/src/tor/CMakeLists.txt.post035
+++ b/src/tor/CMakeLists.txt.post035
@@ -107,6 +107,9 @@ list(REMOVE_ITEM all_src
     ${TOR_ROOT_DIR}/src/ext/ed25519/donna/ed25519.c
     ${TOR_ROOT_DIR}/src/ext/ed25519/donna/test.c
     ${TOR_ROOT_DIR}/src/ext/ed25519/donna/test-internals.c
+    ${TOR_ROOT_DIR}/src/feature/dirauth/dirauth_stub.c
+    ${TOR_ROOT_DIR}/src/feature/dircache/dircache_stub.c
+    ${TOR_ROOT_DIR}/src/feature/relay/relay_stub.c
     ${TOR_ROOT_DIR}/src/lib/tls/nss_countbytes.c
     ${TOR_ROOT_DIR}/src/lib/tls/tortls_nss.c
     ${TOR_ROOT_DIR}/src/lib/tls/x509_nss.c


### PR DESCRIPTION
When trying to build Tor master branch with shadow-plugin-tor, it complains about duplicate symbols.

It seems Tor is making progress on modularizing their codebase.

This PR ignores stub files with empty definitions of functions. (So far) these modules are enabled by default at configure time, so the correct thing to do is to include the real non-stub sources.