### PR TITLE
Add Tor version matrix to CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,9 +20,13 @@ jobs:
       matrix:
         # TODO: add clang. Currently builds but has unsuccessful xfers in simulation.
         cc: ['gcc']
+        # Latest patch version from last few release branches.
+        # See https://gitweb.torproject.org/tor.git/refs/tags
+        tor_version: ['0.3.5.7', '0.4.0.5', '0.4.1.8', '0.4.2.6']
 
     env:
       CC: ${{ matrix.cc }}
+      TOR_VERSION: ${{ matrix.tor_version }}
     
     steps:
       - name: Checkout Shadow

--- a/tools/continuous_integration_test.sh
+++ b/tools/continuous_integration_test.sh
@@ -6,6 +6,7 @@
 
 # Preconditions:
 #  * CC environment var set to preferred C compiler (gcc or clang)
+#  * TOR_VERSION optionally set to the desired Tor version
 #  * ubuntu18 packages are available.
 #  * Run as a sudoer.
 #  * ./shadow-tor-plugin is source directory for shadow-tor-plugin.
@@ -81,9 +82,11 @@ install_shadow_plugin_tor_build_deps () (
 
 install_shadow_plugin_tor () (
     eval "$TRACE_CMD"
-    cd $1
+    local SHADOW_PLUGIN_TOR_SRC=$1
+    local TOR_VERSION=$2
+    cd $SHADOW_PLUGIN_TOR_SRC
     ./setup dependencies -y
-    ./setup build -y
+    ./setup build --tor-version=$TOR_VERSION -y
     ./setup install
 )
 
@@ -120,6 +123,7 @@ main () (
     SHADOW_SRC=$PWD/shadow
     SHADOW_PLUGIN_TOR_SRC=$PWD/shadow-plugin-tor
     SIMULATION_DIR=$PWD/simulation
+    TOR_VERSION=${TOR_VERSION:-0.3.5.7}
 
     install_compiler $CC
 
@@ -130,7 +134,7 @@ main () (
     install_tgen $TGEN_SRC $INSTALL_PREFIX
 
     install_shadow_plugin_tor_build_deps
-    install_shadow_plugin_tor $SHADOW_PLUGIN_TOR_SRC $INSTALL_PREFIX
+    install_shadow_plugin_tor $SHADOW_PLUGIN_TOR_SRC $TOR_VERSION
     
     run_simulation $SIMULATION_DIR $SHADOW_PLUGIN_TOR_SRC $INSTALL_PREFIX/bin/shadow
     validate_simulation $SIMULATION_DIR


### PR DESCRIPTION
Run CI against multiple Tor versions. In addition to 0.3.5.7 (the previous default), added the latest patch release from each of the latest release branches. (There is no stable release for the 0.4.3 branch yet)