### PR TITLE
Tells curl to fail on server error

### DIFF
--- a/setup
+++ b/setup
@@ -590,7 +590,7 @@ def download(url, target_path, preapproved=False):
             logging.error("failed to download \'{0}\' using urllib2".format(url))
             curlpath = which("curl")
             if curlpath is not None:
-                retcode = subprocess.call(shlex.split("{0} -L -O {1}".format(curlpath, url)))
+                retcode = subprocess.call(shlex.split("{0} -f -L -O {1}".format(curlpath, url)))
                 if retcode == 0:
                     logging.info("successfully downloaded \'{0}\' using curl".format(url))
                     return 0


### PR DESCRIPTION
This gives us a faster and easier-to-debug failure vs the previous
behavior of downloading an error status page and then failing later when
the local file doesn't have the expected name and/or contents.