### PR TITLE
Get random bytes without opening a file

### DIFF
--- a/src/tor/shadowtor-preload.c
+++ b/src/tor/shadowtor-preload.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <event2/dns.h>
@@ -145,15 +146,9 @@ int RAND_poll() {
 }
 
 static int _shadowtorpreload_getRandomBytes(unsigned char* buf, int numBytes) {
-    int bytesWritten = 0;
-
-    /* shadow interposes this and will fill the buffer for us */
-    int fd = open("/dev/random", O_RDONLY);
-    int res = read(fd, buf, (size_t)numBytes);
-    assert(res > 0);
-    close(fd);
-
-    return 1;
+    // shadow interposes this and will fill the buffer for us
+    // return 1 on success, 0 otherwise
+    return (numBytes == syscall(SYS_getrandom, buf, (size_t)numBytes, 0)) ? 1 : 0;
 }
 
 int RAND_bytes(unsigned char *buf, int num) {


### PR DESCRIPTION
The `RAND_bytes` function is the second most frequently called function in the preload lib after `EVP_Cipher` in the minimal test case with `tor-v0.4.5.6`:

```
$ grep -r "called function" shadow.data/hosts/*/*stderr | cut -d':' -f2 | sort | uniq -c
 127606 called function EVP_Cipher
    150 called function RAND_add
  23358 called function RAND_bytes
     18 called function RAND_get_rand_method
     27 called function RAND_seed
     27 called function RAND_status
```

The `getrandom` syscall is in both [shadow classic](https://github.com/shadow/shadow/blob/a7e59e04b923bf3fb85129aa9bf4995974f0c7b0/src/main/host/process.c#L4982) and in [shadow phantom](https://github.com/shadow/shadow/blob/ceefeefe99ba055ed509e973f94e79fa6c0b05b2/src/main/host/syscall/random.c#L20) and should be more efficient than opening a file, reading it, and closing it.